### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/centos-7.3"
+  # use "latest"
   runner_version = "RUNNER_VERSION"
   name = "RUNNER_NAME"
   runner_url = "RUNNER_URL"


### PR DESCRIPTION
added a simple comment that recommends use `latest`  version of Gitlab Runner